### PR TITLE
add more memory to nexus

### DIFF
--- a/docs/04-HashiCorp/07-Nomad/05-SampleJob/nexus.md
+++ b/docs/04-HashiCorp/07-Nomad/05-SampleJob/nexus.md
@@ -33,7 +33,7 @@ job "nexus" {
       
       resources {
         cpu    = 1000
-        memory = 2703
+        memory = 8000
       }
     }
   }


### PR DESCRIPTION
You need a minimum of 8 GB, but you are setting the soft limit to 2703 MB.